### PR TITLE
Add tests for evaluate_portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,13 @@ This comprehensive process gives you a robust method for evaluating your modelâ€
 ---
 
 This explanation should help you understand the mechanics of your backtesting code and what kind of output to expect from it.
+
+## Running Tests
+
+This project uses `pytest` for unit tests. After installing the dependencies, run:
+
+```bash
+pytest
+```
+
+The tests are located in the `tests/` directory and cover utility functions like portfolio evaluation.

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import numpy as np
+import pytest
+
+from src.backtest.evaluation import evaluate_portfolio
+
+
+def synthetic_returns_series():
+    return pd.Series(
+        [0.01, -0.02, 0.03, 0.02],
+        index=pd.period_range("2020-01", periods=4, freq="M"),
+        name="returns",
+    )
+
+
+def test_evaluate_portfolio_series():
+    returns = synthetic_returns_series()
+    metrics = evaluate_portfolio(returns)
+
+    # Verify keys
+    expected_keys = {
+        "cumulative_returns",
+        "drawdowns",
+        "mean_return",
+        "std_dev",
+        "sharpe_ratio",
+    }
+    assert set(metrics.keys()) == expected_keys
+
+    cumulative_expected = pd.Series(
+        [1.01, 0.9898, 1.019494, 1.039884], index=returns.index
+    )
+    drawdown_expected = pd.Series([0.0, -0.02, 0.0, 0.0], index=returns.index)
+
+    pd.testing.assert_series_equal(
+        metrics["cumulative_returns"].round(6),
+        cumulative_expected,
+        check_names=False,
+    )
+    pd.testing.assert_series_equal(
+        metrics["drawdowns"].round(6),
+        drawdown_expected,
+        check_names=False,
+    )
+    assert metrics["mean_return"] == pytest.approx(0.01)
+    assert metrics["std_dev"] == pytest.approx(0.02160247)
+    assert metrics["sharpe_ratio"] == pytest.approx(1.60356745)
+
+
+def test_evaluate_portfolio_dataframe():
+    returns = synthetic_returns_series()
+    df = returns.reset_index()
+    df.columns = ["month", "portfolio_return"]
+    df["month"] = df["month"].astype(str)
+
+    metrics = evaluate_portfolio(df)
+
+    cumulative_expected = pd.Series(
+        [1.01, 0.9898, 1.019494, 1.039884], index=pd.to_datetime(df["month"])
+    )
+
+    pd.testing.assert_series_equal(
+        metrics["cumulative_returns"].round(6),
+        cumulative_expected,
+        check_names=False,
+    )
+    pd.testing.assert_series_equal(
+        metrics["drawdowns"].round(6),
+        pd.Series([0.0, -0.02, 0.0, 0.0], index=pd.to_datetime(df["month"])),
+        check_names=False,
+    )
+    assert metrics["mean_return"] == pytest.approx(0.01)
+    assert metrics["std_dev"] == pytest.approx(0.02160247)
+    assert metrics["sharpe_ratio"] == pytest.approx(1.60356745)
+
+


### PR DESCRIPTION
## Summary
- add pytest unit tests for `evaluate_portfolio`
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846de7fae7883248577086e07b31150